### PR TITLE
Make build with `SSL` support optional, and add some examples.

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.5)
+project(frnetlib_test)
+
+if( WIN32 )
+    set( ADDITIONAL_LIB ws2_32 )  # Ws2_32.lib
+
+	set( FRNETLIB_ROOT_PATH "C:/tools/cmake_install_libs/frnetlib/" ) # change it to your install directory
+
+	set( FRNETLIB_INCLUDE_PATH ${FRNETLIB_ROOT_PATH}/include )
+	set( FRNETLIB_LIB ${FRNETLIB_ROOT_PATH}/lib/frnetlib-s-d.lib )
+
+	include_directories( ${FRNETLIB_INCLUDE_PATH} )
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -std=c++14")
+
+elseif(APPLE)
+	set( ADDITIONAL_LIB "" )
+else()
+    set( ADDITIONAL_LIB "" )
+	#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -m64 -fPIC -std=c++14 -pthread -lmbedtls -lmbedx509 -lmbedcrypto")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -m64 -fPIC -std=c++14 -pthread")
+endif()
+
+
+add_executable(${PROJECT_NAME} ../main.cpp)
+add_executable(packet packet.cpp)
+
+
+target_link_libraries(${PROJECT_NAME} ${FRNETLIB_LIB} ${ADDITIONAL_LIB})
+target_link_libraries(packet ${FRNETLIB_LIB} ${ADDITIONAL_LIB})

--- a/examples/packet.cpp
+++ b/examples/packet.cpp
@@ -1,0 +1,14 @@
+#include <iostream>
+#include "frnetlib/Packet.h"
+
+
+int main()
+{
+    fr::Packet packet;
+    std::vector<std::pair<int, int>> bob = {{1, 2}, {3, 4}};
+    packet << bob;
+    bob.clear();
+
+    packet >> bob;
+    std::cout << bob[0].first << ", " << bob[0].second << ", " << bob[1].first << ", " << bob[1].second << std::endl;
+}

--- a/src/SSLListener.cpp
+++ b/src/SSLListener.cpp
@@ -3,10 +3,11 @@
 //
 
 #include <chrono>
-#include <mbedtls/net_sockets.h>
 #include <frnetlib/TcpListener.h>
 #include "frnetlib/SSLListener.h"
 #ifdef SSL_ENABLED
+
+#include <mbedtls/net_sockets.h>
 
 namespace fr
 {

--- a/src/SSLSocket.cpp
+++ b/src/SSLSocket.cpp
@@ -4,9 +4,10 @@
 
 #include "frnetlib/SSLSocket.h"
 #include <memory>
-#include <mbedtls/net_sockets.h>
 
 #ifdef SSL_ENABLED
+
+#include <mbedtls/net_sockets.h>
 
 namespace fr
 {


### PR DESCRIPTION
Hello, I change two lines in `SSLListener.cpp` and  `SSLSocket.cpp`, so that we can build without SSL optional and smoothly. (Note that I did not try to use and build SSL by far ;) ).

And I think it necessary to add example codes or test suites, I just give a possible example in the `example` folder, I think it would be better if you can make the example codes in README into truly and executable codes (with cmake) and test suite would be nice.

And with `find_package` support seems appealing (I am not so into this part).

Thanks again, I will try to port one of my old sockets programs (running on raspberry pi) to a cross-platform one based on this lib. (Just tried, and the `main.cpp` can be run successfully (without `-m64` flag), will check other examples.)
 
Regards.

-- MiaoDX